### PR TITLE
fix: Fixed the rendering of notification content.

### DIFF
--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -1,5 +1,15 @@
 import { Link, useLocation } from "wouter";
-import { Bell, Code, Home, MessageCircle, Moon, Search, Sun, Users } from "lucide-react";
+import {
+  Bell,
+  Code,
+  Home,
+  MessageCircle,
+  Moon,
+  Search,
+  Sun,
+  Users,
+  BellOff
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -107,15 +117,63 @@ export function Header({ currentUser, notificationCount = 0, onSearch }: HeaderP
 
             {/* Notifications */}
             <div className="relative">
-              <Button variant="ghost" size="sm" className="text-gray-600 dark:text-gray-300 hover:text-brand-blue">
-                <Bell size={16} className="mr-1" />
-                Notifications
-                {notificationCount > 0 && (
-                  <Badge className="ml-1 bg-red-500 text-white text-xs px-1 py-0.5 rounded-full">
-                    {notificationCount}
-                  </Badge>
-                )}
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-gray-600 dark:text-gray-300 hover:text-brand-blue relative"
+                  >
+                    <Bell size={16} className="mr-1" />
+                    <span className="hidden lg:block">Notifications</span>
+                    {notificationCount > 0 && (
+                      <Badge className="ml-1 absolute top-0 right-0 size-4 bg-red-500 text-white text-xs px-1 py-0.5 rounded-full flex items-center justify-center">
+                        {notificationCount}
+                      </Badge>
+                    )}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-96 max-h-[80vh] overflow-y-auto p-2 rounded-md shadow-xl border dark:bg-gray-800 bg-white">
+                  {notificationCount === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-12 text-center text-gray-500 dark:text-gray-400 text-sm">
+                      <span className="mb-2">
+                        <BellOff />
+                      </span>
+                      <span>No new notifications</span>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="flex justify-between items-center px-2 py-1 text-xs text-gray-500 dark:text-gray-400">
+                        <span className="font-medium">Notifications</span>
+                        <button className="hover:underline transition text-blue-500 cursor-pointer text-xs">
+                          Mark all as read
+                        </button>
+                      </div>
+
+                      <div className="mt-1 space-y-1">
+                        {Array.from({ length: notificationCount }).map(
+                          (_, i) => (
+                            <DropdownMenuItem
+                              key={i}
+                              className="flex flex-col items-start px-3 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition cursor-pointer group"
+                            >
+                              <div className="flex items-center justify-between w-full">
+                                <h1 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                  Notification title {i + 1}
+                                </h1>
+                                <span className="ml-2 h-2 w-2 rounded-full bg-blue-500 group-hover:bg-blue-600" />
+                              </div>
+                              <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                                The notification description goes here.
+                              </p>
+                            </DropdownMenuItem>
+                          )
+                        )}
+                      </div>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
             {/* Theme Toggle */}


### PR DESCRIPTION
Fixes: #6 

### **Description**

This PR adds a responsive Notification Dropdown Panel

### **Features Implemented**

- Created a dropdown notification panel using `shadcn/ui` components.

- Designed to be fully responsive - works across desktop and mobile headers.

- Handled the empty notification state with a fallback message (`"No new notifications to show here"`).

- Displayed unread notification count with a badge on the bell icon.

- Added a `"Mark all as read"` UI placeholder for future interaction.

### **Preview**
**`notificationCount` not equal to 0**

<img width="1886" height="931" alt="image" src="https://github.com/user-attachments/assets/0370145d-937e-4110-b23b-e147a8799ca7" />

**`notificationCount` equal to 0**

<img width="1894" height="948" alt="image" src="https://github.com/user-attachments/assets/3d1bf27e-73bc-4c8c-9c7e-114b47f142ed" />